### PR TITLE
Create local SQLite cache layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 venv/
 env/
 .cache
+data/cache.db

--- a/app_streamlit.py
+++ b/app_streamlit.py
@@ -10,7 +10,9 @@ import streamlit as st
 from src.spotify_client import get_spotify_client
 from src.dataset import expand_artists_from_user_likes
 from src.recommender import recommend_artists_by_genre
+from src.cache.cache_db import init_db
 
+init_db()
 
 
 #TÍTULO

--- a/src/cache/cache_db.py
+++ b/src/cache/cache_db.py
@@ -1,0 +1,24 @@
+import sqlite3
+from pathlib import Path
+
+DB_PATH = Path("data/cache.db")
+
+
+def get_connection():
+    DB_PATH.parent.mkdir(exist_ok=True)
+    return sqlite3.connect(DB_PATH)
+
+
+def init_db():
+    conn = get_connection()
+    cursor = conn.cursor()
+
+    cursor.execute("""
+    CREATE TABLE IF NOT EXISTS spotify_artist (
+        artist_name TEXT PRIMARY KEY,
+        data TEXT
+    )
+    """)
+
+    conn.commit()
+    conn.close()


### PR DESCRIPTION
This PR introduces a local persistence layer using SQLite
to support caching and reduce repeated Spotify API calls.

- Adds cache module (src/cache)
- Initializes SQLite database on startup
- Prepares foundation for API-level caching

Closes #1
